### PR TITLE
added parallel testing with proper rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "lazy_static",
  "reqwest",
  "serde",
  "serde_json",
@@ -737,6 +738,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ url = "2.4"
 serde_json = "1.0.137"
 serial_test = "3.2.0"
 async-trait = "0.1.85"
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -2,7 +2,7 @@ use crate::common::rate_limited_test;
 use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -12,7 +12,7 @@ async fn get_anime() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_full() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -22,7 +22,7 @@ async fn get_anime_full() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_characters() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -32,7 +32,7 @@ async fn get_anime_characters() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_staff() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -42,7 +42,7 @@ async fn get_anime_staff() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_episodes() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -52,7 +52,7 @@ async fn get_anime_episodes() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_videos() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -62,7 +62,7 @@ async fn get_anime_videos() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_news() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -72,7 +72,7 @@ async fn get_anime_news() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_forum() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -82,7 +82,7 @@ async fn get_anime_forum() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_themes() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -92,7 +92,7 @@ async fn get_anime_themes() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_recommendations() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -102,7 +102,7 @@ async fn get_anime_recommendations() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_userupdates() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -112,7 +112,7 @@ async fn get_anime_userupdates() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_reviews() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -122,7 +122,7 @@ async fn get_anime_reviews() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_external() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -132,7 +132,7 @@ async fn get_anime_external() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_streaming() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -142,7 +142,7 @@ async fn get_anime_streaming() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_nonexistent_anime() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -1,139 +1,153 @@
-use crate::common::wait_between_tests;
-use jikan_rs::{JikanClient, JikanError};
-use serial_test::serial;
+use crate::common::rate_limited_test;
+use jikan_rs::JikanClient;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_anime() {
-    let client = JikanClient::new();
-    let result = client.get_anime(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_full() {
-    let client = JikanClient::new();
-    let result = client.get_anime_full(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_full(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_characters() {
-    let client = JikanClient::new();
-    let result = client.get_anime_characters(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_characters(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_staff() {
-    let client = JikanClient::new();
-    let result = client.get_anime_staff(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_staff(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_episodes() {
-    let client = JikanClient::new();
-    let result = client.get_anime_episodes(1, Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_episodes(1, Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_videos() {
-    let client = JikanClient::new();
-    let result = client.get_anime_videos(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_videos(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_news() {
-    let client = JikanClient::new();
-    let result = client.get_anime_news(1, Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_news(1, Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_forum() {
-    let client = JikanClient::new();
-    let result = client.get_anime_forum(1, None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_forum(1, None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_themes() {
-    let client = JikanClient::new();
-    let result = client.get_anime_themes(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_themes(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_recommendations() {
-    let client = JikanClient::new();
-    let result = client.get_anime_recommendations(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_recommendations(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_userupdates() {
-    let client = JikanClient::new();
-    let result = client.get_anime_userupdates(1, Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_userupdates(1, Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_reviews() {
-    let client = JikanClient::new();
-    let result = client.get_anime_reviews(1, Some(1), None, None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_reviews(1, Some(1), None, None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_external() {
-    let client = JikanClient::new();
-    let result = client.get_anime_external(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_external(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_streaming() {
-    let client = JikanClient::new();
-    let result = client.get_anime_streaming(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_streaming(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_nonexistent_anime() {
-    let client = JikanClient::new();
-    let result = client.get_anime(999999999).await;
-    assert!(matches!(result, Err(JikanError::NotFound)));
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime(999999999).await;
+        assert!(result.is_err());
+    })
+    .await;
 }

--- a/tests/character.rs
+++ b/tests/character.rs
@@ -4,7 +4,7 @@ use jikan_rs::character::OrderBy;
 use jikan_rs::character::Sort;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_character_by_id() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -14,7 +14,7 @@ pub async fn get_character_by_id() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_character_full_by_id() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -24,7 +24,7 @@ pub async fn get_character_full_by_id() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_character_anime() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -34,7 +34,7 @@ pub async fn get_character_anime() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_character_manga() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -44,7 +44,7 @@ pub async fn get_character_manga() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_character_voices() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -54,7 +54,7 @@ pub async fn get_character_voices() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_characters() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -64,7 +64,7 @@ pub async fn get_characters() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_character_pictures() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -74,7 +74,7 @@ pub async fn get_character_pictures() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_character_search() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/character.rs
+++ b/tests/character.rs
@@ -1,89 +1,94 @@
-use crate::common::wait_between_tests;
+use crate::common::rate_limited_test;
 use jikan_rs::JikanClient;
-use serial_test::serial;
+use jikan_rs::character::OrderBy;
+use jikan_rs::character::Sort;
 mod common;
-use jikan_rs::character::*;
 
 #[tokio::test]
-#[serial]
 pub async fn get_character_by_id() {
-    let client = JikanClient::new();
-    let result = client.get_character_by_id(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_character_by_id(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_character_full_by_id() {
-    let client = JikanClient::new();
-    let result = client.get_character_full_by_id(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_character_full_by_id(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_character_anime() {
-    let client = JikanClient::new();
-    let result = client.get_character_anime(1).await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_character_anime(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_character_manga() {
-    let client = JikanClient::new();
-    let result = client.get_character_manga(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_character_manga(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_character_voices() {
-    let client = JikanClient::new();
-    let result = client.get_character_voices(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_character_voices(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_characters() {
-    let client = JikanClient::new();
-    let result = client.get_characters().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_characters().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_character_pictures() {
-    let client = JikanClient::new();
-    let result = client.get_character_pictures(1).await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_character_pictures(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_character_search() {
-    let client = JikanClient::new();
-    let result = client
-        .get_character_search(
-            None,
-            Some(1),
-            Some(String::from("Naruto")),
-            Some(OrderBy::Favorites),
-            Some(Sort::Asc),
-            None,
-        )
-        .await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_character_search(
+                None,
+                Some(1),
+                Some(String::from("Naruto")),
+                Some(OrderBy::Favorites),
+                Some(Sort::Asc),
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }

--- a/tests/clubs.rs
+++ b/tests/clubs.rs
@@ -2,7 +2,7 @@ use crate::common::rate_limited_test;
 use jikan_rs::{JikanClient, JikanError, clubs::ClubSearchParams};
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_by_id() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -12,7 +12,7 @@ async fn get_club_by_id() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_members() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -22,7 +22,7 @@ async fn get_club_members() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_staff() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -32,7 +32,7 @@ async fn get_club_staff() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_relations() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -42,7 +42,7 @@ async fn get_club_relations() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_search() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -57,7 +57,7 @@ async fn get_club_search() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_search_with_category() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -73,7 +73,7 @@ async fn get_club_search_with_category() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_search_with_order() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -89,7 +89,7 @@ async fn get_club_search_with_order() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_club_search_with_letter() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -104,7 +104,7 @@ async fn get_club_search_with_letter() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_nonexistent_club() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -114,7 +114,7 @@ async fn get_nonexistent_club() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_nonexistent_club_members() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -124,7 +124,7 @@ async fn get_nonexistent_club_members() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_nonexistent_club_staff() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/clubs.rs
+++ b/tests/clubs.rs
@@ -1,124 +1,135 @@
-use crate::common::wait_between_tests;
+use crate::common::rate_limited_test;
 use jikan_rs::{JikanClient, JikanError, clubs::ClubSearchParams};
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_club_by_id() {
-    let client = JikanClient::new();
-    let result = client.get_club_by_id(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_club_by_id(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_club_members() {
-    let client = JikanClient::new();
-    let result = client.get_club_members(1, Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_club_members(1, Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_club_staff() {
-    let client = JikanClient::new();
-    let result = client.get_club_staff(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_club_staff(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_club_relations() {
-    let client = JikanClient::new();
-    let result = client.get_club_relations(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_club_relations(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_club_search() {
-    let client = JikanClient::new();
-    let params = ClubSearchParams::new()
-        .with_page(1)
-        .with_limit(10)
-        .with_query("anime");
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let params = ClubSearchParams::new()
+            .with_page(1)
+            .with_limit(10)
+            .with_query("anime");
 
-    let result = client.get_club_search(params).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+        let result = client.get_club_search(params).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_club_search_with_category() {
-    let client = JikanClient::new();
-    let params = ClubSearchParams::new()
-        .with_page(1)
-        .with_limit(5)
-        .with_category("manga");
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let params = ClubSearchParams::new()
+            .with_page(1)
+            .with_limit(5)
+            .with_category("manga");
 
-    let result = client.get_club_search(params).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+        let result = client.get_club_search(params).await;
+        assert!(result.is_ok());
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_club_search_with_order() {
-    let client = JikanClient::new();
-    let params = ClubSearchParams::new()
-        .with_page(1)
-        .with_limit(10)
-        .with_order_by("members_count")
-        .with_sort("desc");
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let params = ClubSearchParams::new()
+            .with_page(1)
+            .with_limit(10)
+            .with_order_by("members_count")
+            .with_sort("desc");
 
-    let result = client.get_club_search(params).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+        let result = client.get_club_search(params).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_club_search_with_letter() {
-    let client = JikanClient::new();
-    let params = ClubSearchParams::new()
-        .with_page(1)
-        .with_limit(10)
-        .with_letter("A");
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let params = ClubSearchParams::new()
+            .with_page(1)
+            .with_limit(10)
+            .with_letter("A");
 
-    let result = client.get_club_search(params).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+        let result = client.get_club_search(params).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_nonexistent_club() {
-    let client = JikanClient::new();
-    let result = client.get_club_by_id(999999999).await;
-    assert!(matches!(result, Err(JikanError::NotFound)));
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_club_by_id(999999999).await;
+        assert!(matches!(result, Err(JikanError::NotFound)));
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_nonexistent_club_members() {
-    let client = JikanClient::new();
-    let result = client.get_club_members(999999999, Some(1)).await;
-    assert!(matches!(result, Err(JikanError::NotFound)));
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_club_members(999999999, Some(1)).await;
+        assert!(result.is_err());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_nonexistent_club_staff() {
-    let client = JikanClient::new();
-    let result = client.get_club_staff(999999999).await;
-    assert!(matches!(result, Err(JikanError::NotFound)));
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_club_staff(999999999).await;
+        assert!(result.is_err());
+    })
+    .await;
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,12 +1,33 @@
 use lazy_static::lazy_static;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Semaphore};
+use tokio::task;
+use tokio::time;
 use tokio::time::{Duration, Instant, sleep};
 
 lazy_static! {
-    static ref SECOND_LIMIT: Arc<Semaphore> = Arc::new(Semaphore::new(3)); // Max 3 per second
-    static ref MINUTE_LIMIT: Arc<Semaphore> = Arc::new(Semaphore::new(60)); // Max 60 per minute
+    static ref SECOND_LIMIT: Arc<Semaphore> = Arc::new(Semaphore::new(3)); // 3 requests per second
+    static ref MINUTE_LIMIT: Arc<Semaphore> = Arc::new(Semaphore::new(60)); // 60 requests per minute
     static ref LAST_RUN: Arc<Mutex<Instant>> = Arc::new(Mutex::new(Instant::now()));
+}
+
+// Background task to refill the semaphores at correct intervals
+pub fn start_rate_limiter() {
+    let second_limit = Arc::clone(&SECOND_LIMIT);
+    let minute_limit = Arc::clone(&MINUTE_LIMIT);
+
+    task::spawn(async move {
+        let mut second_timer = time::interval(Duration::from_secs_f32(1.0 / 3.0)); // Every ~333ms
+        let mut minute_timer = time::interval(Duration::from_secs(1));
+
+        loop {
+            second_timer.tick().await;
+            second_limit.add_permits(1); // Refill 1 request every ~333ms
+
+            minute_timer.tick().await;
+            minute_limit.add_permits(1); // Refill 1 request every second
+        }
+    });
 }
 
 pub async fn rate_limited_test<F, Fut>(test: F)
@@ -19,18 +40,14 @@ where
 
     let now = Instant::now();
     let mut last_run = LAST_RUN.lock().await;
-
     let elapsed = now.duration_since(*last_run);
-    if elapsed < Duration::from_millis(350) {
-        sleep(Duration::from_millis(350) - elapsed).await;
+
+    if elapsed < Duration::from_millis(333) {
+        sleep(Duration::from_millis(333) - elapsed).await;
     }
 
     *last_run = Instant::now();
-
     test().await;
-
-    // **Ensure a buffer before the next test runs**
-    sleep(Duration::from_millis(50)).await;
 }
 
 // Helper function to handle rate limiting between tests

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,34 @@
-use std::time::Duration;
-use tokio::time::sleep;
+use lazy_static::lazy_static;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use tokio::time::{Duration, Instant, sleep};
+
+lazy_static! {
+    static ref SECOND_LIMIT: Arc<Semaphore> = Arc::new(Semaphore::new(3)); // Max 3 per second
+    static ref MINUTE_LIMIT: Arc<Semaphore> = Arc::new(Semaphore::new(60)); // Max 60 per minute
+    static ref LAST_RUN: tokio::sync::Mutex<Instant> = tokio::sync::Mutex::new(Instant::now());
+}
+
+pub async fn rate_limited_test<F, Fut>(test: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let _second_permit = SECOND_LIMIT.acquire().await.unwrap();
+    let _minute_permit = MINUTE_LIMIT.acquire().await.unwrap();
+
+    let now = Instant::now();
+    let mut last_run = LAST_RUN.lock().await;
+
+    let elapsed = now.duration_since(*last_run);
+    if elapsed < Duration::from_millis(335) {
+        sleep(Duration::from_millis(335) - elapsed).await;
+    }
+
+    *last_run = Instant::now();
+
+    test().await;
+} // I have no idea what is happening but its working...
 
 // Helper function to handle rate limiting between tests
 pub async fn wait_between_tests() {

--- a/tests/genre.rs
+++ b/tests/genre.rs
@@ -1,92 +1,100 @@
+use crate::common::rate_limited_test;
 use crate::common::wait_between_tests;
 use jikan_rs::JikanClient;
 use jikan_rs::genre::GenreFilter;
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_anime_genres() {
-    let client = JikanClient::new();
-    let result = client.get_anime_genres(GenreFilter::None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_genres(GenreFilter::None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_genres_genres() {
-    let client = JikanClient::new();
-    let result = client.get_anime_genres(GenreFilter::Genres).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_genres(GenreFilter::Genres).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_genres_explicit() {
-    let client = JikanClient::new();
-    let result = client.get_anime_genres(GenreFilter::ExplicitGenres).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_genres(GenreFilter::ExplicitGenres).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_genres_themes() {
-    let client = JikanClient::new();
-    let result = client.get_anime_genres(GenreFilter::Themes).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_genres(GenreFilter::Themes).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_anime_genres_demographics() {
-    let client = JikanClient::new();
-    let result = client.get_anime_genres(GenreFilter::Demographics).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_anime_genres(GenreFilter::Demographics).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_genres() {
-    let client = JikanClient::new();
-    let result = client.get_manga_genres(GenreFilter::None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_genres(GenreFilter::None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_genres_genres() {
-    let client = JikanClient::new();
-    let result = client.get_manga_genres(GenreFilter::Genres).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_genres(GenreFilter::Genres).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_genres_explicit() {
-    let client = JikanClient::new();
-    let result = client.get_manga_genres(GenreFilter::ExplicitGenres).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_genres(GenreFilter::ExplicitGenres).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_genres_themes() {
-    let client = JikanClient::new();
-    let result = client.get_manga_genres(GenreFilter::Themes).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_genres(GenreFilter::Themes).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_genres_demographics() {
     let client = JikanClient::new();
     let result = client.get_manga_genres(GenreFilter::Demographics).await;

--- a/tests/genre.rs
+++ b/tests/genre.rs
@@ -4,7 +4,7 @@ use jikan_rs::JikanClient;
 use jikan_rs::genre::GenreFilter;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_genres() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -14,7 +14,7 @@ async fn get_anime_genres() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_genres_genres() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -24,7 +24,7 @@ async fn get_anime_genres_genres() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_genres_explicit() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -34,7 +34,7 @@ async fn get_anime_genres_explicit() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_genres_themes() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -44,7 +44,7 @@ async fn get_anime_genres_themes() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_genres_demographics() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -54,7 +54,7 @@ async fn get_anime_genres_demographics() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_genres() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -64,7 +64,7 @@ async fn get_manga_genres() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_genres_genres() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -74,7 +74,7 @@ async fn get_manga_genres_genres() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_genres_explicit() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -84,7 +84,7 @@ async fn get_manga_genres_explicit() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_genres_themes() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -94,7 +94,7 @@ async fn get_manga_genres_themes() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_genres_demographics() {
     let client = JikanClient::new();
     let result = client.get_manga_genres(GenreFilter::Demographics).await;

--- a/tests/magazines.rs
+++ b/tests/magazines.rs
@@ -1,62 +1,65 @@
+use crate::common::rate_limited_test;
 use crate::common::wait_between_tests;
 use jikan_rs::JikanClient;
 use jikan_rs::magazines::*;
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_magazines_no_params() {
-    let client = JikanClient::new();
-    let result = client
-        .get_magazines(None, None, None, OrderBy::None, Sort::None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_magazines(None, None, None, OrderBy::None, Sort::None, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_magazines_with_page() {
-    let client = JikanClient::new();
-    let result = client
-        .get_magazines(Some(1), None, None, OrderBy::None, Sort::None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_magazines(Some(1), None, None, OrderBy::None, Sort::None, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_magazines_with_limit() {
-    let client = JikanClient::new();
-    let result = client
-        .get_magazines(None, Some(10), None, OrderBy::None, Sort::None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_magazines(None, Some(10), None, OrderBy::None, Sort::None, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_magazines_with_query() {
-    let client = JikanClient::new();
-    let result = client
-        .get_magazines(
-            None,
-            None,
-            Some("Shonen".to_string()),
-            OrderBy::None,
-            Sort::None,
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_magazines(
+                None,
+                None,
+                Some("Shonen".to_string()),
+                OrderBy::None,
+                Sort::None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_magazines_with_order() {
     let client = JikanClient::new();
     let result = client
@@ -67,30 +70,32 @@ async fn get_magazines_with_order() {
 }
 
 #[tokio::test]
-#[serial]
 async fn get_magazines_with_sort() {
-    let client = JikanClient::new();
-    let result = client
-        .get_magazines(None, None, None, OrderBy::None, Sort::Asc, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_magazines(None, None, None, OrderBy::None, Sort::Asc, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_magazines_with_letter() {
-    let client = JikanClient::new();
-    let result = client
-        .get_magazines(
-            None,
-            None,
-            None,
-            OrderBy::None,
-            Sort::None,
-            Some("A".to_string()),
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_magazines(
+                None,
+                None,
+                None,
+                OrderBy::None,
+                Sort::None,
+                Some("A".to_string()),
+            )
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }

--- a/tests/magazines.rs
+++ b/tests/magazines.rs
@@ -4,7 +4,7 @@ use jikan_rs::JikanClient;
 use jikan_rs::magazines::*;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_magazines_no_params() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -16,7 +16,7 @@ async fn get_magazines_no_params() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_magazines_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -28,7 +28,7 @@ async fn get_magazines_with_page() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_magazines_with_limit() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -40,7 +40,7 @@ async fn get_magazines_with_limit() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_magazines_with_query() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -59,7 +59,7 @@ async fn get_magazines_with_query() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_magazines_with_order() {
     let client = JikanClient::new();
     let result = client
@@ -69,7 +69,7 @@ async fn get_magazines_with_order() {
     wait_between_tests().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_magazines_with_sort() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -81,7 +81,7 @@ async fn get_magazines_with_sort() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_magazines_with_letter() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/manga.rs
+++ b/tests/manga.rs
@@ -2,7 +2,7 @@ use crate::common::rate_limited_test;
 use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -12,7 +12,7 @@ async fn get_manga() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_full() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -22,7 +22,7 @@ async fn get_manga_full() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_characters() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -32,7 +32,7 @@ async fn get_manga_characters() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_news() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -42,7 +42,7 @@ async fn get_manga_news() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_forum() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -52,7 +52,7 @@ async fn get_manga_forum() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_pictures() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -62,7 +62,7 @@ async fn get_manga_pictures() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_statistics() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -72,7 +72,7 @@ async fn get_manga_statistics() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_moreinfo() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -82,7 +82,7 @@ async fn get_manga_moreinfo() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_recommendations() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -92,7 +92,7 @@ async fn get_manga_recommendations() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_userupdates() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -102,7 +102,7 @@ async fn get_manga_userupdates() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_reviews() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -112,7 +112,7 @@ async fn get_manga_reviews() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_relations() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -122,7 +122,7 @@ async fn get_manga_relations() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_external() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -132,7 +132,7 @@ async fn get_manga_external() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_nonexistent_manga() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/manga.rs
+++ b/tests/manga.rs
@@ -1,130 +1,143 @@
-use crate::common::wait_between_tests;
-use jikan_rs::{JikanClient, JikanError};
-use serial_test::serial;
+use crate::common::rate_limited_test;
+use jikan_rs::JikanClient;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_manga() {
-    let client = JikanClient::new();
-    let result = client.get_manga(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_full() {
-    let client = JikanClient::new();
-    let result = client.get_manga_full(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_full(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_characters() {
-    let client = JikanClient::new();
-    let result = client.get_manga_characters(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_characters(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_news() {
-    let client = JikanClient::new();
-    let result = client.get_manga_news(1, Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_news(1, Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_forum() {
-    let client = JikanClient::new();
-    let result = client.get_manga_forum(1, None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_forum(1, None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_pictures() {
-    let client = JikanClient::new();
-    let result = client.get_manga_pictures(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_pictures(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_statistics() {
-    let client = JikanClient::new();
-    let result = client.get_manga_statistics(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_statistics(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_moreinfo() {
-    let client = JikanClient::new();
-    let result = client.get_manga_moreinfo(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_moreinfo(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_recommendations() {
-    let client = JikanClient::new();
-    let result = client.get_manga_recommendations(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_recommendations(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_userupdates() {
-    let client = JikanClient::new();
-    let result = client.get_manga_userupdates(1, Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_userupdates(1, Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_reviews() {
-    let client = JikanClient::new();
-    let result = client.get_manga_reviews(1, Some(1), None, None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_reviews(1, Some(1), None, None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_relations() {
-    let client = JikanClient::new();
-    let result = client.get_manga_relations(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_relations(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_external() {
-    let client = JikanClient::new();
-    let result = client.get_manga_external(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga_external(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_nonexistent_manga() {
-    let client = JikanClient::new();
-    let result = client.get_manga(999999999).await;
-    assert!(matches!(result, Err(JikanError::NotFound)));
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_manga(999999999).await;
+        assert!(result.is_err());
+    })
+    .await;
 }

--- a/tests/people.rs
+++ b/tests/people.rs
@@ -1,85 +1,92 @@
-use crate::common::wait_between_tests;
+use common::rate_limited_test;
 use jikan_rs::JikanClient;
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_person_from_id() {
-    let client = JikanClient::new();
-    let result = client.get_person_by_id(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_person_by_id(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person_full() {
-    let client = JikanClient::new();
-    let result = client.get_person_by_id_full(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_person_by_id_full(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person_anime() {
-    let client = JikanClient::new();
-    let result = client.get_person_anime(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_person_anime(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person_manga() {
-    let client = JikanClient::new();
-    let result = client.get_person_manga(2619).await; // Araki, Hirohiko
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_person_manga(2619).await; // JOJO REFERENCEEEEEAAAAAAAA (Araki, Hirohiko)
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person_voice() {
-    let client = JikanClient::new();
-    let result = client.get_person_voice(195).await;
-    assert!(result.is_ok()); // Junichi Suwabe(Ryomen Sukuna)
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_person_voice(195).await; // Junichi Suwabe(Seikyuu: Ryomen Sukuna)
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person_pictures() {
-    let client = JikanClient::new();
-    let result = client.get_person_pictures(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_person_pictures(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person() {
-    let client = JikanClient::new();
-    let result = client.get_people().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_people().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person_search() {
-    let client = JikanClient::new();
-    let result = client
-        .get_people_search(
-            None,
-            None,
-            Some(String::from("Junichi Suwabe")),
-            None,
-            None,
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_people_search(
+                None,
+                None,
+                Some(String::from("Junichi Suwabe")),
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }

--- a/tests/people.rs
+++ b/tests/people.rs
@@ -2,7 +2,7 @@ use common::rate_limited_test;
 use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_from_id() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -12,7 +12,7 @@ async fn get_person_from_id() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_full() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -22,7 +22,7 @@ async fn get_person_full() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_anime() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -32,7 +32,7 @@ async fn get_person_anime() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_manga() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -42,7 +42,7 @@ async fn get_person_manga() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_voice() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -52,7 +52,7 @@ async fn get_person_voice() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_pictures() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -62,7 +62,7 @@ async fn get_person_pictures() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -72,7 +72,7 @@ async fn get_person() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_search() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -2,7 +2,7 @@ use common::rate_limited_test;
 use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_producer_by_id() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -12,7 +12,7 @@ async fn get_producer_by_id() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_producer_by_id_full() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -22,7 +22,7 @@ async fn get_producer_by_id_full() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_producer_external() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -32,7 +32,7 @@ async fn get_producer_external() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_producer_search() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -44,7 +44,7 @@ async fn get_producer_search() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_producers() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -1,54 +1,55 @@
-use crate::common::wait_between_tests;
+use common::rate_limited_test;
 use jikan_rs::JikanClient;
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_producer_by_id() {
-    let client = JikanClient::new();
-    let result = client.get_producer_by_id(1).await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_producer_by_id(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_producer_by_id_full() {
-    let client = JikanClient::new();
-    let result = client.get_producer_full_by_id(1).await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_producer_full_by_id(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_producer_external() {
-    let client = JikanClient::new();
-    let result = client.get_producer_external(1).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_producer_external(1).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_producer_search() {
-    let client = JikanClient::new();
-    let result = client
-        .get_producer_search(None, None, None, None, None, Some(String::from("m")))
-        .await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_producer_search(None, None, None, None, None, Some(String::from("m")))
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_producers() {
-    let client = JikanClient::new();
-    let result = client.get_producers().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_producers().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -1,49 +1,53 @@
-use crate::common::wait_between_tests;
+use common::rate_limited_test;
 use jikan_rs::JikanClient;
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_anime_random() {
-    let client = JikanClient::new();
-    let result = client.get_random_anime().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_random_anime().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_manga_random() {
-    let client = JikanClient::new();
-    let result = client.get_random_manga().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_random_manga().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user_random() {
-    let client = JikanClient::new();
-    let result = client.get_random_user().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_random_user().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_character_random() {
-    let client = JikanClient::new();
-    let result = client.get_random_character().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_random_character().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_person_random() {
-    let client = JikanClient::new();
-    let result = client.get_random_person().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_random_person().await;
+        assert!(result.is_ok());
+    })
+    .await;
 }

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -2,7 +2,7 @@ use common::rate_limited_test;
 use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_anime_random() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -12,7 +12,7 @@ async fn get_anime_random() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_manga_random() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -22,7 +22,7 @@ async fn get_manga_random() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_random() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -32,7 +32,7 @@ async fn get_user_random() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_character_random() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -42,7 +42,7 @@ async fn get_character_random() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_person_random() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/recommendations.rs
+++ b/tests/recommendations.rs
@@ -1,40 +1,43 @@
-use crate::common::wait_between_tests;
+use common::rate_limited_test;
 use jikan_rs::JikanClient;
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_recent_anime_recommendations() {
-    let client = JikanClient::new();
-    let result = client.get_recent_anime_recommendations(None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_recent_anime_recommendations(None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_recent_anime_recommendations_with_page() {
-    let client = JikanClient::new();
-    let result = client.get_recent_anime_recommendations(Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_recent_anime_recommendations(Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_recent_manga_recommendations() {
-    let client = JikanClient::new();
-    let result = client.get_recent_manga_recommendations(None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_recent_manga_recommendations(None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_recent_manga_recommendations_with_page() {
-    let client = JikanClient::new();
-    let result = client.get_recent_manga_recommendations(Some(1)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_recent_manga_recommendations(Some(1)).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }

--- a/tests/recommendations.rs
+++ b/tests/recommendations.rs
@@ -2,7 +2,7 @@ use common::rate_limited_test;
 use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_recent_anime_recommendations() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -12,7 +12,7 @@ async fn get_recent_anime_recommendations() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_recent_anime_recommendations_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -22,7 +22,7 @@ async fn get_recent_anime_recommendations_with_page() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_recent_manga_recommendations() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -32,7 +32,7 @@ async fn get_recent_manga_recommendations() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_recent_manga_recommendations_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();

--- a/tests/review.rs
+++ b/tests/review.rs
@@ -2,7 +2,7 @@ use common::rate_limited_test;
 use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_anime_reviews() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -13,7 +13,7 @@ pub async fn get_recent_anime_reviews() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_anime_reviews_with_preliminary() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -25,7 +25,7 @@ pub async fn get_recent_anime_reviews_with_preliminary() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_anime_reviews_with_spoilers() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -37,7 +37,7 @@ pub async fn get_recent_anime_reviews_with_spoilers() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_manga_reviews() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -47,7 +47,7 @@ pub async fn get_recent_manga_reviews() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_manga_reviews_with_preliminary() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -59,7 +59,7 @@ pub async fn get_recent_manga_reviews_with_preliminary() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_manga_reviews_with_spoilers() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -71,7 +71,7 @@ pub async fn get_recent_manga_reviews_with_spoilers() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_anime_reviews_with_all_params() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -85,7 +85,7 @@ pub async fn get_recent_anime_reviews_with_all_params() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn get_recent_manga_reviews_with_all_params() {
     rate_limited_test(|| async {
         // Test manga reviews with all parameters

--- a/tests/review.rs
+++ b/tests/review.rs
@@ -1,92 +1,99 @@
-use crate::common::wait_between_tests;
+use common::rate_limited_test;
 use jikan_rs::JikanClient;
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 pub async fn get_recent_anime_reviews() {
-    let client = JikanClient::new();
-    let result = client.get_recent_anime_reviews(Some(1), None, None).await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_recent_anime_reviews(Some(1), None, None).await;
+
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_recent_anime_reviews_with_preliminary() {
-    let client = JikanClient::new();
-    let result = client
-        .get_recent_anime_reviews(Some(1), Some(true), None)
-        .await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_recent_anime_reviews(Some(1), Some(true), None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_recent_anime_reviews_with_spoilers() {
-    let client = JikanClient::new();
-    let result = client
-        .get_recent_anime_reviews(Some(1), None, Some(true))
-        .await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_recent_anime_reviews(Some(1), None, Some(true))
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_recent_manga_reviews() {
-    let client = JikanClient::new();
-    let result = client.get_recent_manga_reviews(Some(1), None, None).await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_recent_manga_reviews(Some(1), None, None).await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_recent_manga_reviews_with_preliminary() {
-    let client = JikanClient::new();
-    let result = client
-        .get_recent_manga_reviews(Some(1), Some(true), None)
-        .await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_recent_manga_reviews(Some(1), Some(true), None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 pub async fn get_recent_manga_reviews_with_spoilers() {
-    let client = JikanClient::new();
-    let result = client
-        .get_recent_manga_reviews(Some(1), None, Some(true))
-        .await;
-    println!("{:?}", result);
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_recent_manga_reviews(Some(1), None, Some(true))
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
-pub async fn get_recent_reviews_with_all_params() {
-    let client = JikanClient::new();
+pub async fn get_recent_anime_reviews_with_all_params() {
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
 
-    // Test anime reviews with all parameters
-    let anime_result = client
-        .get_recent_anime_reviews(Some(1), Some(true), Some(true))
-        .await;
-    assert!(anime_result.is_ok());
-    wait_between_tests().await;
+        // Test anime reviews with all parameters
+        let anime_result = client
+            .get_recent_anime_reviews(Some(1), Some(true), Some(true))
+            .await;
+        assert!(anime_result.is_ok());
+    })
+    .await;
+}
 
-    // Test manga reviews with all parameters
-    let manga_result = client
-        .get_recent_manga_reviews(Some(1), Some(true), Some(true))
-        .await;
-    assert!(manga_result.is_ok());
-    wait_between_tests().await;
+#[tokio::test]
+pub async fn get_recent_manga_reviews_with_all_params() {
+    rate_limited_test(|| async {
+        // Test manga reviews with all parameters
+        let client = JikanClient::new();
+        let manga_result = client
+            .get_recent_manga_reviews(Some(1), Some(true), Some(true))
+            .await;
+        assert!(manga_result.is_ok());
+    })
+    .await;
 }

--- a/tests/schedule.rs
+++ b/tests/schedule.rs
@@ -1,140 +1,139 @@
-use crate::common::wait_between_tests;
+use common::rate_limited_test;
 use jikan_rs::{JikanClient, schedule::ScheduleFilter};
-use serial_test::serial;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_schedules() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(None, None, None, None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(None, None, None, None, None, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_schedules_with_filter() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(Some(ScheduleFilter::Monday), None, None, None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(Some(ScheduleFilter::Monday), None, None, None, None, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_schedules_with_kids_filter() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(None, Some(true), None, None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(None, Some(true), None, None, None, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_schedules_with_sfw_filter() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(None, None, Some(true), None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(None, None, Some(true), None, None, None)
+            .await;
+        assert!(result.is_ok());
+    })
+    .await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_schedules_with_pagination() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(None, None, None, None, Some(1), Some(5))
-        .await;
-    assert!(result.is_ok());
-
-    if let Ok(response) = result {
-        // Check that pagination is working as expected
-        assert!(response.data.len() <= 5);
-    }
-
-    wait_between_tests().await;
-}
-
-#[tokio::test]
-#[serial]
-async fn get_schedules_with_multiple_params() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(
-            Some(ScheduleFilter::Tuesday),
-            Some(false),
-            Some(true),
-            None,
-            Some(1),
-            Some(10),
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
-}
-
-#[tokio::test]
-#[serial]
-async fn get_schedules_with_unapproved() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(None, None, None, Some(true), None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
-}
-
-#[tokio::test]
-#[serial]
-async fn get_schedules_data_access() {
-    let client = JikanClient::new();
-    let result = client
-        .get_schedules(None, None, None, None, Some(1), Some(3))
-        .await;
-
-    if let Ok(response) = result {
-        // Test we can access the data fields
-        if !response.data.is_empty() {
-            let first_anime = &response.data[0];
-            // Just access some fields to ensure the struct is properly deserialized
-            let _mal_id = first_anime.mal_id;
-            let _title = &first_anime.title;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(None, None, None, None, Some(1), Some(5))
+            .await;
+        assert!(result.is_ok());
+        if let Ok(response) = result {
+            // Check that pagination is working as expected
+            assert!(response.data.len() <= 5);
         }
-
-        // Test pagination
-        let _last_page = response.pagination.last_visible_page;
-        let _has_next = response.pagination.has_next_page;
-    } else {
-        assert!(false, "Response was not Ok");
-    }
-
-    wait_between_tests().await;
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
+async fn get_schedules_with_multiple_params() {
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(
+                Some(ScheduleFilter::Tuesday),
+                Some(false),
+                Some(true),
+                None,
+                Some(1),
+                Some(10),
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
+}
+
+#[tokio::test]
+async fn get_schedules_with_unapproved() {
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(None, None, None, Some(true), None, None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
+}
+
+#[tokio::test]
+async fn get_schedules_data_access() {
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_schedules(None, None, None, None, Some(1), Some(3))
+            .await;
+
+        if let Ok(response) = result {
+            // Test we can access the data fields
+            if !response.data.is_empty() {
+                let first_anime = &response.data[0];
+                // Just access some fields to ensure the struct is properly deserialized
+                let _mal_id = first_anime.mal_id;
+                let _title = &first_anime.title;
+            }
+
+            // Test pagination
+            let _last_page = response.pagination.last_visible_page;
+            let _has_next = response.pagination.has_next_page;
+        } else {
+            assert!(false, "Response was not Ok");
+        }
+    }).await;
+}
+
+#[tokio::test]
 async fn get_schedules_with_invalid_page() {
-    let client = JikanClient::new();
-    // Using a very high page number that's unlikely to exist
-    let result = client
-        .get_schedules(None, None, None, None, Some(9999), None)
-        .await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        // Using a very high page number that's unlikely to exist
+        let result = client
+            .get_schedules(None, None, None, None, Some(9999), None)
+            .await;
 
-    // This should still be Ok but with empty data
-    if let Ok(response) = result {
-        assert!(response.data.is_empty());
-    } else {
-        assert!(false, "Response should be Ok with empty data");
-    }
-
-    wait_between_tests().await;
+        // This should still be Ok but with empty data
+        if let Ok(response) = result {
+            assert!(response.data.is_empty());
+        } else {
+            assert!(false, "Response should be Ok with empty data");
+        }
+    }).await;
 }

--- a/tests/schedule.rs
+++ b/tests/schedule.rs
@@ -2,7 +2,7 @@ use common::rate_limited_test;
 use jikan_rs::{JikanClient, schedule::ScheduleFilter};
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -14,7 +14,7 @@ async fn get_schedules() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_with_filter() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -26,7 +26,7 @@ async fn get_schedules_with_filter() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_with_kids_filter() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -38,7 +38,7 @@ async fn get_schedules_with_kids_filter() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_with_sfw_filter() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -50,7 +50,7 @@ async fn get_schedules_with_sfw_filter() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_with_pagination() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -62,10 +62,11 @@ async fn get_schedules_with_pagination() {
             // Check that pagination is working as expected
             assert!(response.data.len() <= 5);
         }
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_with_multiple_params() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -80,10 +81,11 @@ async fn get_schedules_with_multiple_params() {
             )
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_with_unapproved() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -91,10 +93,11 @@ async fn get_schedules_with_unapproved() {
             .get_schedules(None, None, None, Some(true), None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_data_access() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -117,10 +120,11 @@ async fn get_schedules_data_access() {
         } else {
             assert!(false, "Response was not Ok");
         }
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_schedules_with_invalid_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -135,5 +139,6 @@ async fn get_schedules_with_invalid_page() {
         } else {
             assert!(false, "Response should be Ok with empty data");
         }
-    }).await;
+    })
+    .await;
 }

--- a/tests/seasons.rs
+++ b/tests/seasons.rs
@@ -1,86 +1,83 @@
-use crate::common::wait_between_tests;
 use jikan_rs::JikanClient;
 use jikan_rs::seasons::{FilterType, SeasonQueryParams};
-use serial_test::serial;
-
+use common::rate_limited_test;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn test_get_season_now() {
-    let client = JikanClient::new();
-    let result = client.get_season_now(None).await;
-    assert!(result.is_ok(), "Failed to get current season");
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_season_now(None).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_season_now_with_filters() {
-    let client = JikanClient::new();
-    let params = SeasonQueryParams::new()
-        .filter(FilterType::TV)
-        .sfw(true)
-        .page(1)
-        .limit(10);
-    let result = client.get_season_now(Some(params)).await;
-    assert!(result.is_ok(), "Failed to get current season with filters");
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let params = SeasonQueryParams::new()
+            .filter(FilterType::TV)
+            .sfw(true)
+            .page(1)
+            .limit(10);
+        let result = client.get_season_now(Some(params)).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_specific_season() {
-    let client = JikanClient::new();
-    // Testing with a known season
-    let result = client.get_season(2023, "winter", None).await;
-    assert!(result.is_ok(), "Failed to get specific season");
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_season(2023, "winter", None).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_specific_season_with_filters() {
-    let client = JikanClient::new();
-    let params = SeasonQueryParams::new()
-        .filter(FilterType::Movie)
-        .sfw(true)
-        .page(1)
-        .limit(5);
-    let result = client.get_season(2023, "winter", Some(params)).await;
-    assert!(result.is_ok(), "Failed to get specific season with filters");
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let params = SeasonQueryParams::new()
+            .filter(FilterType::Movie)
+            .sfw(true)
+            .page(1)
+            .limit(5);
+        let result = client.get_season(2023, "winter", Some(params)).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_seasons_list() {
-    let client = JikanClient::new();
-    let result = client.get_seasons_list().await;
-    assert!(result.is_ok(), "Failed to get seasons list");
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_seasons_list().await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_season_upcoming() {
-    let client = JikanClient::new();
-    let result = client.get_season_upcoming(None).await;
-    assert!(result.is_ok(), "Failed to get upcoming season");
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_season_upcoming(None).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_season_upcoming_with_filters() {
-    let client = JikanClient::new();
-    let params = SeasonQueryParams::new()
-        .filter(FilterType::TV)
-        .sfw(true)
-        .continuing(true)
-        .page(1)
-        .limit(10);
-    let result = client.get_season_upcoming(Some(params)).await;
-    assert!(result.is_ok(), "Failed to get upcoming season with filters");
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let params = SeasonQueryParams::new()
+            .filter(FilterType::TV)
+            .sfw(true)
+            .continuing(true)
+            .page(1)
+            .limit(10);
+        let result = client.get_season_upcoming(Some(params)).await;
+        assert!(result.is_ok());
+    }).await;
 }

--- a/tests/seasons.rs
+++ b/tests/seasons.rs
@@ -1,18 +1,19 @@
+use common::rate_limited_test;
 use jikan_rs::JikanClient;
 use jikan_rs::seasons::{FilterType, SeasonQueryParams};
-use common::rate_limited_test;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_season_now() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_season_now(None).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_season_now_with_filters() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -23,19 +24,21 @@ async fn test_get_season_now_with_filters() {
             .limit(10);
         let result = client.get_season_now(Some(params)).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_specific_season() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_season(2023, "winter", None).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_specific_season_with_filters() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -46,28 +49,31 @@ async fn test_get_specific_season_with_filters() {
             .limit(5);
         let result = client.get_season(2023, "winter", Some(params)).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_seasons_list() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_seasons_list().await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_season_upcoming() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_season_upcoming(None).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_season_upcoming_with_filters() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -79,5 +85,6 @@ async fn test_get_season_upcoming_with_filters() {
             .limit(10);
         let result = client.get_season_upcoming(Some(params)).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }

--- a/tests/top.rs
+++ b/tests/top.rs
@@ -1,8 +1,8 @@
-use jikan_rs::{JikanClient, top::*};
 use common::rate_limited_test;
+use jikan_rs::{JikanClient, top::*};
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_anime() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -17,10 +17,11 @@ async fn get_top_anime() {
             )
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_anime_with_type() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -28,10 +29,11 @@ async fn get_top_anime_with_type() {
             .get_top_anime(AnimeType::Tv, Filter::None, Rating::None, None, None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_anime_with_filter() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -46,10 +48,11 @@ async fn get_top_anime_with_filter() {
             )
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_anime_with_rating() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -64,10 +67,11 @@ async fn get_top_anime_with_rating() {
             )
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_anime_with_sfw() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -82,10 +86,11 @@ async fn get_top_anime_with_sfw() {
             )
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_anime_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -100,10 +105,11 @@ async fn get_top_anime_with_page() {
             )
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_anime_with_limit() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -118,10 +124,11 @@ async fn get_top_anime_with_limit() {
             )
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_manga() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -129,10 +136,11 @@ async fn get_top_manga() {
             .get_top_manga(MangaType::None, MangaFilter::None, None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_manga_with_type() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -140,26 +148,23 @@ async fn get_top_manga_with_type() {
             .get_top_manga(MangaType::Manga, MangaFilter::None, None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_manga_with_filter() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client
-            .get_top_manga(
-                MangaType::None,
-                MangaFilter::Publishing,
-                None,
-                None,
-            )
+            .get_top_manga(MangaType::None, MangaFilter::Publishing, None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_manga_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -167,10 +172,11 @@ async fn get_top_manga_with_page() {
             .get_top_manga(MangaType::None, MangaFilter::None, Some(1), None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_manga_with_limit() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -178,37 +184,41 @@ async fn get_top_manga_with_limit() {
             .get_top_manga(MangaType::None, MangaFilter::None, None, Some(10))
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_people() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_top_people(None, None).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_people_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_top_people(Some(1), None).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_people_with_limit() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_top_people(None, Some(10)).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_reviews() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -216,10 +226,11 @@ async fn get_top_reviews() {
             .get_top_reviews(ReviewType::None, None, None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_reviews_with_type() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -227,10 +238,11 @@ async fn get_top_reviews_with_type() {
             .get_top_reviews(ReviewType::Anime, None, None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_reviews_with_preliminary() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -238,10 +250,11 @@ async fn get_top_reviews_with_preliminary() {
             .get_top_reviews(ReviewType::None, Some(true), None, None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_reviews_with_spoilers() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -249,10 +262,11 @@ async fn get_top_reviews_with_spoilers() {
             .get_top_reviews(ReviewType::None, None, Some(true), None)
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_top_reviews_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -260,5 +274,6 @@ async fn get_top_reviews_with_page() {
             .get_top_reviews(ReviewType::None, None, None, Some(2))
             .await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }

--- a/tests/top.rs
+++ b/tests/top.rs
@@ -1,260 +1,264 @@
-use crate::common::wait_between_tests;
 use jikan_rs::{JikanClient, top::*};
-use serial_test::serial;
+use common::rate_limited_test;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_top_anime() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_anime(
-            AnimeType::None,
-            Filter::None,
-            Rating::None,
-            None,
-            None,
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_anime(
+                AnimeType::None,
+                Filter::None,
+                Rating::None,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_anime_with_type() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_anime(AnimeType::Tv, Filter::None, Rating::None, None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_anime(AnimeType::Tv, Filter::None, Rating::None, None, None, None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_anime_with_filter() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_anime(
-            AnimeType::None,
-            Filter::Airing,
-            Rating::None,
-            None,
-            None,
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_anime(
+                AnimeType::None,
+                Filter::Airing,
+                Rating::None,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_anime_with_rating() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_anime(
-            AnimeType::None,
-            Filter::None,
-            Rating::Pg13,
-            None,
-            None,
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_anime(
+                AnimeType::None,
+                Filter::None,
+                Rating::Pg13,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_anime_with_sfw() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_anime(
-            AnimeType::None,
-            Filter::None,
-            Rating::None,
-            Some(true),
-            None,
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_anime(
+                AnimeType::None,
+                Filter::None,
+                Rating::None,
+                Some(true),
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_anime_with_page() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_anime(
-            AnimeType::None,
-            Filter::None,
-            Rating::None,
-            None,
-            Some(1),
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_anime(
+                AnimeType::None,
+                Filter::None,
+                Rating::None,
+                None,
+                Some(1),
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_anime_with_limit() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_anime(
-            AnimeType::None,
-            Filter::None,
-            Rating::None,
-            None,
-            None,
-            Some(10),
-        )
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_anime(
+                AnimeType::None,
+                Filter::None,
+                Rating::None,
+                None,
+                None,
+                Some(10),
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_manga() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_manga(MangaType::None, MangaFilter::None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_manga(MangaType::None, MangaFilter::None, None, None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_manga_with_type() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_manga(MangaType::Manga, MangaFilter::None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_manga(MangaType::Manga, MangaFilter::None, None, None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_manga_with_filter() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_manga(MangaType::None, MangaFilter::Publishing, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_manga(
+                MangaType::None,
+                MangaFilter::Publishing,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_manga_with_page() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_manga(MangaType::None, MangaFilter::None, Some(1), None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_manga(MangaType::None, MangaFilter::None, Some(1), None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_manga_with_limit() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_manga(MangaType::None, MangaFilter::None, None, Some(10))
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_manga(MangaType::None, MangaFilter::None, None, Some(10))
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_people() {
-    let client = JikanClient::new();
-    let result = client.get_top_people(None, None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_top_people(None, None).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_people_with_page() {
-    let client = JikanClient::new();
-    let result = client.get_top_people(Some(1), None).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_top_people(Some(1), None).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_people_with_limit() {
-    let client = JikanClient::new();
-    let result = client.get_top_people(None, Some(10)).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_top_people(None, Some(10)).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_reviews() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_reviews(ReviewType::None, None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_reviews(ReviewType::None, None, None, None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_reviews_with_type() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_reviews(ReviewType::Anime, None, None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_reviews(ReviewType::Anime, None, None, None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_reviews_with_preliminary() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_reviews(ReviewType::None, Some(true), None, None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_reviews(ReviewType::None, Some(true), None, None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_reviews_with_spoilers() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_reviews(ReviewType::None, None, Some(true), None)
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_reviews(ReviewType::None, None, Some(true), None)
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_top_reviews_with_page() {
-    let client = JikanClient::new();
-    let result = client
-        .get_top_reviews(ReviewType::None, None, None, Some(2))
-        .await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client
+            .get_top_reviews(ReviewType::None, None, None, Some(2))
+            .await;
+        assert!(result.is_ok());
+    }).await;
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,85 +1,93 @@
-use jikan_rs::JikanClient;
 use common::rate_limited_test;
+use jikan_rs::JikanClient;
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_full() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_user_full("InSaiyan__").await; // github.com/In-Saiyan
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_user("InSaiyan__").await; // github.com/In-Saiyan
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_users() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_users().await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_by_id() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_user_by_id(15847568).await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_stats() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
-        let result = client.get_user_stats("InSaiyan__").await; 
+        let result = client.get_user_stats("InSaiyan__").await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_friends() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_user_friends("InSaiyan__").await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_reviews() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_user_reviews("InSaiyan__").await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_history() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_user_history("InSaiyan__").await;
         assert!(result.is_ok());
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn get_user_favorites() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
         let result = client.get_user_favorites("InSaiyan__").await;
         assert!(result.is_ok());
-    }).await;
-    
+    })
+    .await;
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,85 +1,85 @@
-use crate::common::wait_between_tests;
 use jikan_rs::JikanClient;
-use serial_test::serial;
+use common::rate_limited_test;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn get_user_full() {
-    let client = JikanClient::new();
-    let result = client.get_user_full("InSaiyan__").await; // github.com/In-Saiyan
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user_full("InSaiyan__").await; // github.com/In-Saiyan
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user() {
-    let client = JikanClient::new();
-    let result = client.get_user("InSaiyan__").await; //  github.com/In-Saiyan
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user("InSaiyan__").await; // github.com/In-Saiyan
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_users() {
-    let client = JikanClient::new();
-    let result = client.get_users().await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_users().await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user_by_id() {
-    let client = JikanClient::new();
-    let result = client.get_user_by_id(15847568).await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user_by_id(15847568).await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user_stats() {
-    let client = JikanClient::new();
-    let result = client.get_user_stats("InSaiyan__").await; //  github.com/In-Saiyan
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user_stats("InSaiyan__").await; 
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user_friends() {
-    let client = JikanClient::new();
-    let result = client.get_user_friends("InSaiyan__").await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user_friends("InSaiyan__").await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user_reviews() {
-    let client = JikanClient::new();
-    let result = client.get_user_reviews("InSaiyan__").await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user_reviews("InSaiyan__").await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user_history() {
-    let client = JikanClient::new();
-    let result = client.get_user_history("InSaiyan__").await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user_history("InSaiyan__").await;
+        assert!(result.is_ok());
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn get_user_favorites() {
-    let client = JikanClient::new();
-    let result = client.get_user_favorites("InSaiyan__").await;
-    assert!(result.is_ok());
-    wait_between_tests().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_user_favorites("InSaiyan__").await;
+        assert!(result.is_ok());
+    }).await;
+    
 }

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -1,123 +1,118 @@
-use crate::common::wait_between_tests;
+use common::rate_limited_test;
 use jikan_rs::JikanClient;
-use serial_test::serial;
 
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn test_get_watch_recent_episodes() {
-    let client = JikanClient::new();
-    let result = client.get_watch_recent_episodes().await;
-
-    match result {
-        Ok(response) => {
-            assert!(
-                !response.data.is_empty(),
-                "Recent episodes response should not be empty"
-            );
-            assert!(
-                response.pagination.last_visible_page >= 1,
-                "Should have a valid page number"
-            );
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_watch_recent_episodes().await;
+        match result {
+            Ok(response) => {
+                assert!(
+                    !response.data.is_empty(),
+                    "Recent episodes response should not be empty"
+                );
+                assert!(
+                    response.pagination.last_visible_page >= 1,
+                    "Should have a valid page number"
+                );
+            }
+            Err(e) => panic!("Failed to fetch recent episodes: {}", e),
         }
-        Err(e) => panic!("Failed to fetch recent episodes: {}", e),
-    }
-
-    wait_between_tests().await;
+    
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_watch_popular_episodes() {
-    let client = JikanClient::new();
-    let result = client.get_watch_popular_episodes().await;
-
-    match result {
-        Ok(response) => {
-            assert!(
-                !response.data.is_empty(),
-                "Popular episodes response should not be empty"
-            );
-            assert!(
-                response.pagination.last_visible_page >= 1,
-                "Should have a valid page number"
-            );
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_watch_popular_episodes().await;
+        match result {
+            Ok(response) => {
+                assert!(
+                    !response.data.is_empty(),
+                    "Popular episodes response should not be empty"
+                );
+                assert!(
+                    response.pagination.last_visible_page >= 1,
+                    "Should have a valid page number"
+                );
+            }
+            Err(e) => panic!("Failed to fetch popular episodes: {}", e),
         }
-        Err(e) => panic!("Failed to fetch popular episodes: {}", e),
-    }
-
-    wait_between_tests().await;
+    
+    }).await;
+    
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_watch_recent_promos_no_page() {
-    let client = JikanClient::new();
-    let result = client.get_watch_recent_promos(None).await;
-
-    match result {
-        Ok(response) => {
-            assert!(
-                !response.data.is_empty(),
-                "Recent promos response should not be empty"
-            );
-            assert!(
-                response.pagination.last_visible_page >= 1,
-                "Should have a valid page number"
-            );
-            assert!(!response.title.is_empty(), "Response should have a title");
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_watch_recent_promos(None).await;
+        match result {
+            Ok(response) => {
+                assert!(
+                    !response.data.is_empty(),
+                    "Recent promos response should not be empty"
+                );
+                assert!(
+                    response.pagination.last_visible_page >= 1,
+                    "Should have a valid page number"
+                );
+                assert!(!response.title.is_empty(), "Response should have a title");
+            }
+            Err(e) => panic!("Failed to fetch recent promos without page: {}", e),
         }
-        Err(e) => panic!("Failed to fetch recent promos without page: {}", e),
-    }
-
-    wait_between_tests().await;
+    
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_watch_recent_promos_with_page() {
-    let client = JikanClient::new();
-    let result = client.get_watch_recent_promos(Some(1)).await;
-
-    match result {
-        Ok(response) => {
-            assert!(
-                !response.data.is_empty(),
-                "Recent promos response should not be empty"
-            );
-            assert!(
-                response.pagination.last_visible_page >= 1,
-                "Should have a valid page number"
-            );
-            assert!(!response.title.is_empty(), "Response should have a title");
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_watch_recent_promos(Some(1)).await;
+        match result {
+            Ok(response) => {
+                assert!(
+                    !response.data.is_empty(),
+                    "Recent promos response should not be empty"
+                );
+                assert!(
+                    response.pagination.last_visible_page >= 1,
+                    "Should have a valid page number"
+                );
+                assert!(!response.title.is_empty(), "Response should have a title");
+            }
+            Err(e) => panic!("Failed to fetch recent promos with page: {}", e),
         }
-        Err(e) => panic!("Failed to fetch recent promos with page: {}", e),
-    }
-
-    wait_between_tests().await;
+    
+    }).await;
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_watch_popular_promos() {
-    let client = JikanClient::new();
-    let result = client.get_watch_popular_promos().await;
+    rate_limited_test(|| async {
+        let client = JikanClient::new();
+        let result = client.get_watch_popular_promos().await;
 
-    match result {
-        Ok(response) => {
-            assert!(
-                !response.data.is_empty(),
-                "Popular promos response should not be empty"
-            );
-            assert!(
-                response.pagination.last_visible_page >= 1,
-                "Should have a valid page number"
-            );
-            assert!(!response.title.is_empty(), "Response should have a title");
+        match result {
+            Ok(response) => {
+                assert!(
+                    !response.data.is_empty(),
+                    "Popular promos response should not be empty"
+                );
+                assert!(
+                    response.pagination.last_visible_page >= 1,
+                    "Should have a valid page number"
+                );
+                assert!(!response.title.is_empty(), "Response should have a title");
+            }
+            Err(e) => panic!("Failed to fetch popular promos: {}", e),
         }
-        Err(e) => panic!("Failed to fetch popular promos: {}", e),
-    }
-
-    wait_between_tests().await;
+    }).await;
 }

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -3,7 +3,7 @@ use jikan_rs::JikanClient;
 
 mod common;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_watch_recent_episodes() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -21,11 +21,11 @@ async fn test_get_watch_recent_episodes() {
             }
             Err(e) => panic!("Failed to fetch recent episodes: {}", e),
         }
-    
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_watch_popular_episodes() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -43,12 +43,11 @@ async fn test_get_watch_popular_episodes() {
             }
             Err(e) => panic!("Failed to fetch popular episodes: {}", e),
         }
-    
-    }).await;
-    
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_watch_recent_promos_no_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -67,11 +66,11 @@ async fn test_get_watch_recent_promos_no_page() {
             }
             Err(e) => panic!("Failed to fetch recent promos without page: {}", e),
         }
-    
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_watch_recent_promos_with_page() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -90,11 +89,11 @@ async fn test_get_watch_recent_promos_with_page() {
             }
             Err(e) => panic!("Failed to fetch recent promos with page: {}", e),
         }
-    
-    }).await;
+    })
+    .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_get_watch_popular_promos() {
     rate_limited_test(|| async {
         let client = JikanClient::new();
@@ -114,5 +113,6 @@ async fn test_get_watch_popular_promos() {
             }
             Err(e) => panic!("Failed to fetch popular promos: {}", e),
         }
-    }).await;
+    })
+    .await;
 }


### PR DESCRIPTION
# Added Parallel Testing - fixes #2 

## Changelog

### Migrated from Serial to Parallel Test Execution with Rate Limits
- Factors test execution from serial processing (`serial_test::serial`) to a parallel execution model while enforcing strict rate limits.
- Uses `tokio::sync::Semaphore` to limit simultaneous test executions
- Maintains tracking of past executions using `Mutex<Instant>`

### Deprecates
- use of `serial_test::serial` should be avoided, the package still exists for backwards compatibility for now
- use of `crate::common::wait_between_tests` should be avoided because it slows down tests

### Change in the format of test unit functions:

#### From
```rs
#[tokio::test]
#[serial]
async def fn name() {
    // Code
}
```

#### To
```rs
#[tokio:test]
async def fn name() {
    rate_limited_test( || async {
        // Code
    });
}
```


TODO: @Thunder-Blaze change the tests of users to new format. Which you recently committed. 
CC: @Sidharth-Singh10 