### PR TITLE
Feature/add get_anime_search

### DIFF
--- a/src/anime.rs
+++ b/src/anime.rs
@@ -215,7 +215,18 @@ impl JikanClient {
                 query_params.push(format!("limit={}", l));
             }
             if let Some(t) = p.type_ {
-                query_params.push(format!("type={:?}", t));
+                let anime_type = match t {
+                    AnimeType::CM => "cm",
+                    AnimeType::Movie => "movie",
+                    AnimeType::Music => "music",
+                    AnimeType::ONA => "ona",
+                    AnimeType::OVA => "ova",
+                    AnimeType::PV => "pv",
+                    AnimeType::Special => "special",
+                    AnimeType::TV => "tv",
+                    AnimeType::TVSpecial => "tv_special",
+                };
+                query_params.push(format!("type={}", anime_type));
             }
             match p.score {
                 //* this is due the fact that the query may not have 'score' alongside 'min_score' or 'max_score'
@@ -230,10 +241,23 @@ impl JikanClient {
                 }
             }
             if let Some(st) = p.status {
-                query_params.push(format!("status={:?}", st));
+                let status = match st {
+                    Status::Airing => "airing",
+                    Status::Complete => "complete",
+                    Status::Upcoming => "upcoming",
+                };
+                query_params.push(format!("status={}", status));
             }
             if let Some(r) = p.rating {
-                query_params.push(format!("rating={:?}", r));
+                let rating = match r {
+                    Rating::G => "g",
+                    Rating::Pg => "pg",
+                    Rating::Pg13 => "pg13",
+                    Rating::R17 => "r17",
+                    Rating::R => "r",
+                    Rating::Rx => "rx",
+                };
+                query_params.push(format!("rating={}", rating));
             }
             if let Some(s) = p.sfw {
                 query_params.push(format!("sfw={}", s));
@@ -245,10 +269,27 @@ impl JikanClient {
                 query_params.push(format!("genres_exclude={}", ge));
             }
             if let Some(o) = p.order_by {
-                query_params.push(format!("order_by={:?}", o));
+                let order_by = match o {
+                    OrderBy::EndDate => "end_date",
+                    OrderBy::Episodes => "episodes",
+                    OrderBy::Favorites => "favorites",
+                    OrderBy::MalId => "mal_id",
+                    OrderBy::Members => "members",
+                    OrderBy::Popularity => "popularity",
+                    OrderBy::Rank => "rank",
+                    OrderBy::Score => "score",
+                    OrderBy::ScoredBy => "scored_by",
+                    OrderBy::StartDate => "start_date",
+                    OrderBy::Title => "title",
+                };
+                query_params.push(format!("order_by={}", order_by));
             }
             if let Some(s) = p.sort {
-                query_params.push(format!("sort={:?}", s));
+                let sort = match s {
+                    Sort::Asc => "asc",
+                    Sort::Desc => "desc",
+                };
+                query_params.push(format!("sort={}", sort));
             }
             if let Some(l) = p.letter {
                 query_params.push(format!("letter={}", l));

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -1,7 +1,7 @@
 // anime.rs
 use crate::{
     JikanClient, JikanError,
-    character::*,
+    character::Character,
     common::{DateRange, Images, Pagination},
     misc::*,
     people::*,
@@ -113,6 +113,44 @@ pub enum AnimeType {
     TVSpecial,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Sort {
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OrderBy {
+    MalId,
+    Title,
+    StartDate,
+    EndDate,
+    Episodes,
+    Score,
+    ScoredBy,
+    Rank,
+    Popularity,
+    Members,
+    Favorites,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Status {
+    Airing,
+    Complete,
+    Upcoming,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Rating {
+    G,
+    Pg,
+    Pg13,
+    R17,
+    R,
+    Rx,
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct SearchParams<'a> {
     pub unapproved: Option<bool>,
@@ -122,13 +160,13 @@ pub struct SearchParams<'a> {
     pub score: Option<f32>,
     pub min_score: Option<f32>,
     pub max_score: Option<f32>,
-    pub status: Option<&'a str>,
-    pub rating: Option<&'a str>,
+    pub status: Option<Status>,
+    pub rating: Option<Rating>,
     pub sfw: Option<bool>,
     pub genres: Option<&'a str>,
     pub genres_exclude: Option<&'a str>,
-    pub order_by: Option<&'a str>,
-    pub sort: Option<&'a str>,
+    pub order_by: Option<OrderBy>,
+    pub sort: Option<Sort>,
     pub letter: Option<&'a str>,
     pub producers: Option<&'a str>,
     pub start_date: Option<&'a str>,
@@ -193,10 +231,10 @@ impl JikanClient {
                 query_params.push(format!("max_score={}", max));
             }
             if let Some(st) = p.status {
-                query_params.push(format!("status={}", st));
+                query_params.push(format!("status={:?}", st));
             }
             if let Some(r) = p.rating {
-                query_params.push(format!("rating={}", r));
+                query_params.push(format!("rating={:?}", r));
             }
             if let Some(s) = p.sfw {
                 query_params.push(format!("sfw={}", s));
@@ -208,10 +246,10 @@ impl JikanClient {
                 query_params.push(format!("genres_exclude={}", ge));
             }
             if let Some(o) = p.order_by {
-                query_params.push(format!("order_by={}", o));
+                query_params.push(format!("order_by={:?}", o));
             }
             if let Some(s) = p.sort {
-                query_params.push(format!("sort={}", s));
+                query_params.push(format!("sort={:?}", s));
             }
             if let Some(l) = p.letter {
                 query_params.push(format!("letter={}", l));

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -167,7 +167,6 @@ pub struct SearchParams<'a> {
     pub genres_exclude: Option<&'a str>,
     pub order_by: Option<OrderBy>,
     pub sort: Option<Sort>,
-    pub letter: Option<&'a str>,
     pub producers: Option<&'a str>,
     pub start_date: Option<&'a str>,
     pub end_date: Option<&'a str>,
@@ -252,9 +251,6 @@ impl JikanClient {
             }
             if let Some(s) = p.sort {
                 query_params.push(format!("sort={:?}", s));
-            }
-            if let Some(l) = p.letter {
-                query_params.push(format!("letter={}", l));
             }
             if let Some(p) = p.producers {
                 query_params.push(format!("producers={}", p));

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -135,7 +135,47 @@ pub struct SearchParams<'a> {
     pub end_date: Option<&'a str>,
 }
 
+impl<'a> Default for SearchParams<'a> {
+    fn default() -> Self {
+        SearchParams {
+            unapproved: None,
+            page: None,
+            limit: None,
+            type_: None,
+            score: None,
+            min_score: None,
+            max_score: None,
+            status: None,
+            rating: None,
+            sfw: None,
+            genres: None,
+            genres_exclude: None,
+            order_by: None,
+            sort: None,
+            letter: None,
+            producers: None,
+            start_date: None,
+            end_date: None,
+        }
+    }
+}
+
 impl JikanClient {
+    fn format_search_query(query: &str) -> String {
+        query
+            .to_lowercase()
+            .chars()
+            .map(|c| match c {
+                ' ' => '-',
+                c if c.is_alphanumeric() => c,
+                _ => ' ',
+            })
+            .collect::<String>()
+            .split_whitespace()
+            .collect::<Vec<&str>>()
+            .join("-")
+    }
+
     pub async fn get_anime(&self, id: i32) -> Result<AnimeResponse<Anime>, JikanError> {
         self.get(&format!("/anime/{}", id)).await
     }
@@ -151,8 +191,9 @@ impl JikanClient {
             )));
         }
 
+        let formatted_q = Self::format_search_query(q);
         let mut query_params = Vec::new();
-        query_params.push(format!("q={}", q));
+        query_params.push(format!("q={}", formatted_q));
 
         if let Some(p) = params {
             if let Some(u) = p.unapproved {

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -135,7 +135,7 @@ pub struct SearchParams<'a> {
     pub end_date: Option<&'a str>,
 }
 
-impl<'a> Default for SearchParams<'a> {
+impl Default for SearchParams<'_> {
     fn default() -> Self {
         SearchParams {
             unapproved: None,

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -113,7 +113,7 @@ pub enum AnimeType {
     TVSpecial,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct SearchParams<'a> {
     pub unapproved: Option<bool>,
     pub page: Option<u32>,
@@ -133,31 +133,6 @@ pub struct SearchParams<'a> {
     pub producers: Option<&'a str>,
     pub start_date: Option<&'a str>,
     pub end_date: Option<&'a str>,
-}
-
-impl Default for SearchParams<'_> {
-    fn default() -> Self {
-        SearchParams {
-            unapproved: None,
-            page: None,
-            limit: None,
-            type_: None,
-            score: None,
-            min_score: None,
-            max_score: None,
-            status: None,
-            rating: None,
-            sfw: None,
-            genres: None,
-            genres_exclude: None,
-            order_by: None,
-            sort: None,
-            letter: None,
-            producers: None,
-            start_date: None,
-            end_date: None,
-        }
-    }
 }
 
 impl JikanClient {

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -100,9 +100,119 @@ pub struct EpisodeVideo {
     pub title: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AnimeType {
+    TV,
+    Movie,
+    OVA,
+    Special,
+    ONA,
+    Music,
+    CM,
+    PV,
+    TVSpecial,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchParams<'a> {
+    pub unapproved: Option<bool>,
+    pub page: Option<u32>,
+    pub limit: Option<u32>,
+    pub type_: Option<AnimeType>,
+    pub score: Option<f32>,
+    pub min_score: Option<f32>,
+    pub max_score: Option<f32>,
+    pub status: Option<&'a str>,
+    pub rating: Option<&'a str>,
+    pub sfw: Option<bool>,
+    pub genres: Option<&'a str>,
+    pub genres_exclude: Option<&'a str>,
+    pub order_by: Option<&'a str>,
+    pub sort: Option<&'a str>,
+    pub letter: Option<&'a str>,
+    pub producers: Option<&'a str>,
+    pub start_date: Option<&'a str>,
+    pub end_date: Option<&'a str>,
+}
+
 impl JikanClient {
     pub async fn get_anime(&self, id: i32) -> Result<AnimeResponse<Anime>, JikanError> {
         self.get(&format!("/anime/{}", id)).await
+    }
+
+    pub async fn get_anime_search(
+        &self,
+        q: &str,
+        params: Option<SearchParams<'_>>,
+    ) -> Result<AnimeResponse<Vec<Anime>>, JikanError> {
+        if q.is_empty() {
+            return Err(JikanError::BadRequest(String::from(
+                "Param q must be specified!",
+            )));
+        }
+
+        let mut query_params = Vec::new();
+        query_params.push(format!("q={}", q));
+
+        if let Some(p) = params {
+            if let Some(u) = p.unapproved {
+                query_params.push(format!("unapproved={}", u));
+            }
+            if let Some(p) = p.page {
+                query_params.push(format!("page={}", p));
+            }
+            if let Some(l) = p.limit {
+                query_params.push(format!("limit={}", l));
+            }
+            if let Some(t) = p.type_ {
+                query_params.push(format!("type={:?}", t));
+            }
+            if let Some(s) = p.score {
+                query_params.push(format!("score={}", s));
+            }
+            if let Some(min) = p.min_score {
+                query_params.push(format!("min_score={}", min));
+            }
+            if let Some(max) = p.max_score {
+                query_params.push(format!("max_score={}", max));
+            }
+            if let Some(st) = p.status {
+                query_params.push(format!("status={}", st));
+            }
+            if let Some(r) = p.rating {
+                query_params.push(format!("rating={}", r));
+            }
+            if let Some(s) = p.sfw {
+                query_params.push(format!("sfw={}", s));
+            }
+            if let Some(g) = p.genres {
+                query_params.push(format!("genres={}", g));
+            }
+            if let Some(ge) = p.genres_exclude {
+                query_params.push(format!("genres_exclude={}", ge));
+            }
+            if let Some(o) = p.order_by {
+                query_params.push(format!("order_by={}", o));
+            }
+            if let Some(s) = p.sort {
+                query_params.push(format!("sort={}", s));
+            }
+            if let Some(l) = p.letter {
+                query_params.push(format!("letter={}", l));
+            }
+            if let Some(p) = p.producers {
+                query_params.push(format!("producers={}", p));
+            }
+            if let Some(s) = p.start_date {
+                query_params.push(format!("start_date={}", s));
+            }
+            if let Some(e) = p.end_date {
+                query_params.push(format!("end_date={}", e));
+            }
+        }
+
+        let query = format!("?{}", query_params.join("&"));
+        self.get(&format!("/anime{}", query)).await
     }
 
     pub async fn get_anime_full(&self, id: i32) -> Result<AnimeResponse<Anime>, JikanError> {

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -221,14 +221,16 @@ impl JikanClient {
             if let Some(t) = p.type_ {
                 query_params.push(format!("type={:?}", t));
             }
-            if let Some(s) = p.score {
-                query_params.push(format!("score={}", s));
-            }
-            if let Some(min) = p.min_score {
-                query_params.push(format!("min_score={}", min));
-            }
-            if let Some(max) = p.max_score {
-                query_params.push(format!("max_score={}", max));
+            match p.score {     //* this is due the fact that the query may not have 'score' alongside 'min_score' or 'max_score'
+                Some(score) => query_params.push(format!("score={}", score)),
+                None => {
+                    if let Some(min) = p.min_score {
+                        query_params.push(format!("min_score={}", min));
+                    }
+                    if let Some(max) = p.max_score {
+                        query_params.push(format!("max_score={}", max));
+                    }
+                }
             }
             if let Some(st) = p.status {
                 query_params.push(format!("status={:?}", st));

--- a/src/people.rs
+++ b/src/people.rs
@@ -2,7 +2,7 @@
 use crate::{
     JikanClient, JikanError,
     anime::*,
-    character::{Sort, OrderBy, *},
+    character::{OrderBy, Sort, *},
     common::{Images, Pagination},
     manga::*,
 };

--- a/src/people.rs
+++ b/src/people.rs
@@ -2,7 +2,7 @@
 use crate::{
     JikanClient, JikanError,
     anime::*,
-    character::*,
+    character::{Sort, OrderBy, *},
     common::{Images, Pagination},
     manga::*,
 };

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -1,6 +1,7 @@
 use crate::common::wait_between_tests;
 use jikan_rs::{
-    anime::{AnimeType, OrderBy, Rating, SearchParams, Sort, Status}, JikanClient, JikanError
+    JikanClient, JikanError,
+    anime::{AnimeType, OrderBy, Rating, SearchParams, Sort, Status},
 };
 use serial_test::serial;
 mod common;
@@ -19,29 +20,28 @@ async fn get_anime() {
 async fn get_anime_search() {
     let client = JikanClient::new();
     let params = SearchParams {
+        q: Some("Death"),
         status: Some(Status::Complete),
-        sfw: Some(true),
-        limit: Some(5),
+        sfw: Some(false),
+        limit: Some(10),
         type_: Some(AnimeType::TV),
         unapproved: Some(false),
         page: Some(1),
         // score: Some(8.62),   //* score can not be provided if there is an min_score or max_score
-        min_score: Some(2.00),  //* min_score and max_score will be ignored if score is passed
+        min_score: Some(2.00), //* min_score and max_score will be ignored if score is passed
         max_score: Some(9.00),
-        rating: Some(Rating::R),
+        rating: Some(Rating::Pg13),
         genres: Some("10"),
         genres_exclude: Some("2"),
-        order_by: Some(OrderBy::Title),
+        order_by: Some(OrderBy::MalId),
         sort: Some(Sort::Asc),
-        // letter: Some("d"),     //* this param can not be provided alongside the q param, it will be deprecated
+        // letter: Some("d"),     //* this param can not be provided alongside the q param
         producers: Some("102"),
-        start_date: Some("1997-01-01"),    //* the param for 'start_date' and 'end_date' MUST follow the YYYY-MM-DD date format
+        start_date: Some("1997-01-01"), //* the param for 'start_date' and 'end_date' MUST follow the YYYY-MM-DD date format
         end_date: Some("2025-05-01"),
         ..Default::default()
     };
-    let result = client
-        .get_anime_search("Death", Some(params))
-        .await;
+    let result = client.get_anime_search(Some(params)).await;
     assert!(result.is_ok());
     wait_between_tests().await;
 }

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -26,17 +26,17 @@ async fn get_anime_search() {
         unapproved: Some(false),
         page: Some(1),
         // score: Some(8.62),   //* score can not be provided if there is an min_score or max_score
-        min_score: Some(2.00),
+        min_score: Some(2.00),  //* min_score and max_score will be ignored if score is passed
         max_score: Some(9.00),
         rating: Some(Rating::R),
         genres: Some("10"),
         genres_exclude: Some("2"),
         order_by: Some(OrderBy::Title),
         sort: Some(Sort::Asc),
-        // letter: Some("d"),     //* this param can not be provided alongside the q param
+        // letter: Some("d"),     //* this param can not be provided alongside the q param, it will be deprecated
         producers: Some("102"),
-        start_date: Some("1997-01-01"),    //* the param for these two MUST follow the YYYY-MM-DD date format
-        end_date: Some("2025-05-01"),      //*
+        start_date: Some("1997-01-01"),    //* the param for 'start_date' and 'end_date' MUST follow the YYYY-MM-DD date format
+        end_date: Some("2025-05-01"),
         ..Default::default()
     };
     let result = client

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -14,6 +14,15 @@ async fn get_anime() {
 
 #[tokio::test]
 #[serial]
+async fn get_anime_search() {
+    let client = JikanClient::new();
+    let result = client.get_anime_search("naruto", None).await;
+    assert!(result.is_ok());
+    wait_between_tests().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn get_anime_full() {
     let client = JikanClient::new();
     let result = client.get_anime_full(1).await;

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -25,18 +25,18 @@ async fn get_anime_search() {
         type_: Some(AnimeType::TV),
         unapproved: Some(false),
         page: Some(1),
-        score: Some(8.62),
-        // min_score: Some(2.00),   //* panics when used
-        // max_score: Some(9.00),   //* panics when used
+        // score: Some(8.62),   //* score can not be provided if there is an min_score or max_score
+        min_score: Some(2.00),
+        max_score: Some(9.00),
         rating: Some(Rating::R),
         genres: Some("10"),
         genres_exclude: Some("2"),
         order_by: Some(OrderBy::Title),
         sort: Some(Sort::Asc),
-        // letter: Some("d"),     // @dark1zinn: Actually, idk what this letter query do excatly. + //* panics when used
+        // letter: Some("d"),     //* this param can not be provided alongside the q param
         producers: Some("102"),
-        // start_date: Some("1997"),    //* panics when used
-        // end_date: Some("2025"),      //* panics when used
+        start_date: Some("1997-01-01"),    //* the param for these two MUST follow the YYYY-MM-DD date format
+        end_date: Some("2025-05-01"),      //*
         ..Default::default()
     };
     let result = client

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -1,5 +1,7 @@
 use crate::common::wait_between_tests;
-use jikan_rs::{JikanClient, JikanError, anime::SearchParams};
+use jikan_rs::{
+    anime::{AnimeType, OrderBy, Rating, SearchParams, Sort, Status}, JikanClient, JikanError
+};
 use serial_test::serial;
 mod common;
 
@@ -17,10 +19,24 @@ async fn get_anime() {
 async fn get_anime_search() {
     let client = JikanClient::new();
     let params = SearchParams {
-        status: Some("airing"),
+        status: Some(Status::Airing),
         sfw: Some(true),
         limit: Some(5),
-        ..Default::default()
+        type_: Some(AnimeType::TV),
+        unapproved: Some(false),
+        page: Some(3),
+        score: Some(9.00),
+        min_score: Some(4.00),
+        max_score: Some(9.65),
+        rating: Some(Rating::R),
+        genres: Some("24,46"),
+        genres_exclude: Some("1,2"),
+        order_by: Some(OrderBy::Title),
+        sort: Some(Sort::Asc),
+        letter: Some(None),     // @dark1zinn: I ran out of references/ideas
+        producers: Some(None),
+        start_date: Some(None),
+        end_date: Some(None),
     };
     let result = client
         .get_anime_search("Dragon Ball: Z", Some(params))

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -19,27 +19,28 @@ async fn get_anime() {
 async fn get_anime_search() {
     let client = JikanClient::new();
     let params = SearchParams {
-        status: Some(Status::Airing),
+        status: Some(Status::Complete),
         sfw: Some(true),
         limit: Some(5),
         type_: Some(AnimeType::TV),
         unapproved: Some(false),
-        page: Some(3),
-        score: Some(9.00),
-        min_score: Some(4.00),
-        max_score: Some(9.65),
+        page: Some(1),
+        score: Some(8.62),
+        // min_score: Some(2.00),   //* panics when used
+        // max_score: Some(9.00),   //* panics when used
         rating: Some(Rating::R),
-        genres: Some("24,46"),
-        genres_exclude: Some("1,2"),
+        genres: Some("10"),
+        genres_exclude: Some("2"),
         order_by: Some(OrderBy::Title),
         sort: Some(Sort::Asc),
-        letter: Some(None),     // @dark1zinn: I ran out of references/ideas
-        producers: Some(None),
-        start_date: Some(None),
-        end_date: Some(None),
+        // letter: Some("d"),     // @dark1zinn: Actually, idk what this letter query do excatly. + //* panics when used
+        producers: Some("102"),
+        // start_date: Some("1997"),    //* panics when used
+        // end_date: Some("2025"),      //* panics when used
+        ..Default::default()
     };
     let result = client
-        .get_anime_search("Dragon Ball: Z", Some(params))
+        .get_anime_search("Death", Some(params))
         .await;
     assert!(result.is_ok());
     wait_between_tests().await;

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -1,5 +1,5 @@
 use crate::common::wait_between_tests;
-use jikan_rs::{JikanClient, JikanError};
+use jikan_rs::{anime::SearchParams, JikanClient, JikanError};
 use serial_test::serial;
 mod common;
 
@@ -16,7 +16,13 @@ async fn get_anime() {
 #[serial]
 async fn get_anime_search() {
     let client = JikanClient::new();
-    let result = client.get_anime_search("naruto", None).await;
+    let params = SearchParams {
+        status: Some("airing"),
+        sfw: Some(true),
+        limit: Some(5),
+        ..Default::default()
+    };
+    let result = client.get_anime_search("Dragon Ball: Z", Some(params)).await;
     assert!(result.is_ok());
     wait_between_tests().await;
 }

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -1,5 +1,5 @@
 use crate::common::wait_between_tests;
-use jikan_rs::{anime::SearchParams, JikanClient, JikanError};
+use jikan_rs::{JikanClient, JikanError, anime::SearchParams};
 use serial_test::serial;
 mod common;
 
@@ -22,7 +22,9 @@ async fn get_anime_search() {
         limit: Some(5),
         ..Default::default()
     };
-    let result = client.get_anime_search("Dragon Ball: Z", Some(params)).await;
+    let result = client
+        .get_anime_search("Dragon Ball: Z", Some(params))
+        .await;
     assert!(result.is_ok());
     wait_between_tests().await;
 }


### PR DESCRIPTION
## Adds feature for `get_anime_search` - Resolves https://github.com/Sidharth-Singh10/jikan-rs/issues/9#issue-3049368071

For a better understanding please refer to issue #9 

#### Changes made:
- Added `get_anime_search` in JikanClient impl at [src/anime.rs:183](https://github.com/dark1zinn/jikan-rs/blob/6a7472835755739157a7c294cbd0586913525572/src/anime.rs#L183)
- Added struct `SearchParams` and enum `AnimeType` at [src/anime.rs:117](https://github.com/dark1zinn/jikan-rs/blob/6a7472835755739157a7c294cbd0586913525572/src/anime.rs#L117) and [src/anime.rs:104](https://github.com/dark1zinn/jikan-rs/blob/6a7472835755739157a7c294cbd0586913525572/src/anime.rs#L104)
- Added non pub utility fn `format_search_query` for formatting the string passed in the param `q` at `get_anime_search` to get rid of special characters and replacing spaces at [src/anime.rs:164](https://github.com/dark1zinn/jikan-rs/blob/6a7472835755739157a7c294cbd0586913525572/src/anime.rs#L164)
- Added test for `get_anime_search` at [tests/anime.rs:17](https://github.com/dark1zinn/jikan-rs/blob/6a7472835755739157a7c294cbd0586913525572/tests/anime.rs#L17)
