### PR TITLE
Changes `get_anime_full` result to `AnimeExtended`  and struct updates

### DIFF
--- a/src/anime.rs
+++ b/src/anime.rs
@@ -1,14 +1,10 @@
 // anime.rs
 use crate::{
-    JikanClient, JikanError,
-    enums::{
+    common::structs::anime::AnimeExtended, enums::{
         anime::{AnimeOrder, AnimeRating, AnimeStatus, AnimeType},
         common::Sort,
         forum::ForumFilter,
-    },
-    format_search_query,
-    response::Response,
-    structs::{
+    }, format_search_query, response::Response, structs::{
         anime::{
             Anime, AnimeForum, AnimeRelation, AnimeStatistics, AnimeThemes, MoreInfo, StaffMember,
         },
@@ -18,8 +14,7 @@ use crate::{
         reviews::Review,
         users::UserUpdate,
         watch::{Episode, Videos},
-    },
-    utils::{ExternalEntry, Images},
+    }, utils::{ExternalEntry, Images}, JikanClient, JikanError
 };
 
 #[derive(Default)]
@@ -149,7 +144,7 @@ impl JikanClient {
         self.get(&format!("/anime{}", query)).await
     }
 
-    pub async fn get_anime_full(&self, id: i32) -> Result<Response<Anime>, JikanError> {
+    pub async fn get_anime_full(&self, id: i32) -> Result<Response<AnimeExtended>, JikanError> {
         self.get(&format!("/anime/{}/full", id)).await
     }
 

--- a/src/anime.rs
+++ b/src/anime.rs
@@ -1,10 +1,15 @@
 // anime.rs
 use crate::{
-    common::structs::anime::AnimeExtended, enums::{
+    JikanClient, JikanError,
+    common::structs::anime::AnimeExtended,
+    enums::{
         anime::{AnimeOrder, AnimeRating, AnimeStatus, AnimeType},
         common::Sort,
         forum::ForumFilter,
-    }, format_search_query, response::Response, structs::{
+    },
+    format_search_query,
+    response::Response,
+    structs::{
         anime::{
             Anime, AnimeForum, AnimeRelation, AnimeStatistics, AnimeThemes, MoreInfo, StaffMember,
         },
@@ -14,7 +19,8 @@ use crate::{
         reviews::Review,
         users::UserUpdate,
         watch::{Episode, Videos},
-    }, utils::{ExternalEntry, Images}, JikanClient, JikanError
+    },
+    utils::{ExternalEntry, Images},
 };
 
 #[derive(Default)]

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -30,10 +30,16 @@ pub struct ImageSet {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DateRangeProp {
+pub struct DateRangePropFromTo {
     pub day: Option<u32>,
     pub month: Option<u32>,
     pub year: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DateRangeProp {
+    pub from: DateRangePropFromTo,
+    pub to: Option<DateRangePropFromTo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/anime.rs
+++ b/tests/anime.rs
@@ -52,7 +52,7 @@ async fn get_anime_search() {
 #[serial]
 async fn get_anime_full() {
     let client = JikanClient::new();
-    let result = client.get_anime_full(1).await;
+    let result = client.get_anime_full(52991).await;
     assert!(result.is_ok());
     wait_between_tests().await;
 }


### PR DESCRIPTION
## Corrects the `get_anime_full` success result - fixes #13 
### Changes made:
- Changed succes return type from `Anime` to `AnimeExtended`, wich actually covers all fields.
- Updated `DateRangeProp` struct to correctly support both `from` and `to` fields.
- Created `DaterangePropFromTo` struct to assist the `DateRangeProp` struct.

I did run the test to make sure it is working properly, but it can happen that i missed somenthing, please be patient with me 👍 
> Note that the `to` field is an `Option`, cause animes that arent completed doesn't have an end date.
