### PR TITLE
Fix: query type changed to String

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -27,7 +27,7 @@ impl JikanClient {
         &self,
         page: Option<i32>,
         limit: Option<i32>,
-        query: Option<i32>,
+        query: Option<String>,
         order_by: Option<ProducersOrder>,
         sort: Option<Sort>,
         letter: Option<String>,
@@ -41,7 +41,9 @@ impl JikanClient {
             params.push(format!("limit={}", lim));
         }
         if let Some(q) = query {
-            params.push(format!("q={}", q));
+            if !q.is_empty() {
+                params.push(format!("q={}", q));
+            }
         }
         if let Some(o) = order_by {
             params.push(format!("order_by={}", o.as_str()));


### PR DESCRIPTION
### Summary

This PR updates the `query` parameter in the `get_producer_search` method from `i32` to `Option<String>`.

### Reason

The Jikan API's `q` query parameter is meant to accept search terms as strings, not integers. Previously, the method only allowed numeric search queries, which limited usability.

With this update, the method now supports full-text search queries like `"Kyoto Animation"` or `"Toei"`, aligning better with the Jikan API spec and improving developer experience.

### Impact

No breaking changes to existing method signature besides the type update. Consumers of this method will now need to pass a `String` instead of an `i32` for the `query` argument.