### PR TITLE
Fix: `get_season_now()` return type mismatch

### DIFF
--- a/src/seasons.rs
+++ b/src/seasons.rs
@@ -1,6 +1,6 @@
 use crate::{
     JikanClient, JikanError,
-    common::response::Response,
+    common::{response::Response, structs::anime::AnimeExtended},
     enums::season::SeasonFilter,
     structs::{anime::Anime, season::SeasonInfo},
 };
@@ -105,7 +105,7 @@ impl JikanClient {
     pub async fn get_season_now(
         &self,
         params: Option<SeasonQueryParams>,
-    ) -> Result<Response<Vec<Anime>>, JikanError> {
+    ) -> Result<Response<Vec<AnimeExtended>>, JikanError> {
         let mut query_params = Vec::new();
 
         if let Some(p) = params {


### PR DESCRIPTION
Changed return type of `get_season_now()` from `Anime` to `AnimeExtended`: Fixes #19 

Unfortunaltelly i have not checked for other occurrencies of this mismatch, but feel free to add it to [my fork](https://github.com/dark1zinn/jikan-rs) and i will add it as soon as possible to have it merged.

I have indeed runned the tests multiple times to make sure everything was fine with this change, check the screenshots below:

![Screenshot 2025-06-13 135701](https://github.com/user-attachments/assets/5934c77c-063d-43c2-b67f-2f4f7631c0ce)
`Please note at the query in the terminal, wich points no 'genres' field`
<br>

![Screenshot 2025-06-13 135816](https://github.com/user-attachments/assets/b8f40e38-a03f-4648-b1b0-96680c81d1e1)
`Now the test but with the return type changed, note that now the JSON does contains the 'genres' fields`